### PR TITLE
Added multithreading -

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -250,3 +250,4 @@ paket-files/
 # JetBrains Rider
 .idea/
 *.sln.iml
+*.bin

--- a/FilesGalore.sln
+++ b/FilesGalore.sln
@@ -1,11 +1,14 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.24720.0
+VisualStudioVersion = 14.0.25123.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "FilesGalore", "FilesGalore\FilesGalore.vcxproj", "{095CEC9E-4FA3-45F3-9409-4A7F8FDD3FD1}"
 EndProject
 Global
+	GlobalSection(Performance) = preSolution
+		HasPerformanceSessions = true
+	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
 		Debug|x86 = Debug|x86


### PR DESCRIPTION
 one thread creates all even-numbered files and one thread creates all odd-numbered files.

There is a bottleneck with the leftToWrite member inside createJunk as it is not thread-safe and requires a mutex, however there is still a small performance gain.

Changed argument format to -f #### instead of -f#### (i.e. added a space).